### PR TITLE
CFC-52: Add support for editing existing contacts as an admin

### DIFF
--- a/includes/class-civicrm-caldera-forms-helper.php
+++ b/includes/class-civicrm-caldera-forms-helper.php
@@ -1042,8 +1042,9 @@ class CiviCRM_Caldera_Forms_Helper {
 		// Try logged in user if no cid supplied
 		elseif ( is_user_logged_in() ) {
 			$contact = $this->get_current_contact();
-			$this->current_contact_data = $contact;
 		}
+
+		$this->current_contact_data = $contact;
 
 		return $contact;
 

--- a/includes/class-civicrm-caldera-forms-helper.php
+++ b/includes/class-civicrm-caldera-forms-helper.php
@@ -1026,21 +1026,21 @@ class CiviCRM_Caldera_Forms_Helper {
 		$contact = false;
 
 		// checksum links first
-		if ( isset( $_GET['cid'] ) && isset( $_GET['cs'] ) ) {
+		if ( isset( $_GET['cid'] ) ) {
 
 			$cid = $_GET['cid'];
-			$cs = $_GET['cs'];
+			$cs = isset( $_GET['cs'] ) ? $_GET['cs'] : '';
 
-			// Check for valid checksum
-			$valid_user = CRM_Contact_BAO_Contact_Utils::validChecksum( $cid, $cs );
+			// Check for contact permissions or valid checksum
+			$valid_user = CRM_Contact_BAO_Contact_Permission::allow($cid, CRM_Core_Permission::EDIT)
+			              || ($cs && CRM_Contact_BAO_Contact_Utils::validChecksum( $cid, $cs ));
 
 			if ( $valid_user )
 				$contact = $this->plugin->helper->get_civi_contact( $cid );
 
 		}
-
-		// logged in overrides checksum
-		if ( is_user_logged_in() ) {
+		// Try logged in user if no cid supplied
+		elseif ( is_user_logged_in() ) {
 			$contact = $this->get_current_contact();
 			$this->current_contact_data = $contact;
 		}

--- a/processors/contact/class-contact-processor.php
+++ b/processors/contact/class-contact-processor.php
@@ -154,7 +154,7 @@ class CiviCRM_Caldera_Forms_Contact_Processor {
 
 			if ( is_array( $first_contact_processor ) && $first_contact_processor['ID'] == $config['processor_id'] && isset( $config['auto_pop'] ) ) {
 				// logged in contact
-				$contact = $this->plugin->helper->get_current_contact();
+				$contact = $this->plugin->helper->current_contact_data_get();
 				// if not logged in, do dedupe
 				$contact_id = $contact ? $contact['contact_id'] : $this->plugin->helper->civi_contact_dedupe(
 					$form_values['civicrm_contact'], // contact data


### PR DESCRIPTION
Overview
----------------------------------------
Allow _cid=n_ in the URL to load other contacts when logged in

Before
----------------------------------------
When logged in, only contact information for the logged-in user can be used to prefill forms.

After
----------------------------------------
If a _cid=n_ parameter is provided to the form, it checks if the user has permission to edit that contact and loads it instead.
If the logged in contact does not have permission to edit the specified contact, no contact is loaded.

Comments
----------------------------------------
This changes the behaviour where cid is ignored when the user is logged in.

I think this is justified as loading the contact of the currently logged in user when a cid is specified is significantly unintuitive and can cause unintended data changes, like users overwriting their own contact details.
It's better to load no contact and create a new one than to update the wrong contact.