### PR TITLE
CFC-55: Only trigger auto-population for additional contacts with Rel…

### DIFF
--- a/processors/contact/class-contact-processor.php
+++ b/processors/contact/class-contact-processor.php
@@ -713,7 +713,7 @@ class CiviCRM_Caldera_Forms_Contact_Processor {
 
 				} else {
 
-					if ( empty( $related_contacts ) && empty( $pr_id['config']['auto_pop'] ) ) continue;
+					if ( empty( $related_contacts ) || empty( $pr_id['config']['auto_pop'] ) ) continue;
 
 					// continue if we don't have contact data for this processor
 					if ( empty( $related_contacts[$pr_id['ID']] ) ) continue;


### PR DESCRIPTION
…ationship processor when option is checked.

Overview
----------------------------------------
Only trigger auto-population for additional contacts with Relationship processor when option is checked.

Before
----------------------------------------
When additional Contact processors have an associated Relationship processor, fields for that Contact are prefilled whether the option for auto-population is set on that contact or not.
This is a regression introduced with commit 63c8e5f

After
----------------------------------------
Fields for Contact processors are only auto-populated when requested.
