### PR TITLE
Strpos will never return "flase"

### DIFF
--- a/processors/participant/class-participant-processor.php
+++ b/processors/participant/class-participant-processor.php
@@ -187,7 +187,7 @@ class CiviCRM_Caldera_Forms_Participant_Processor {
 			if ( ! empty( $config['campaign_id'] ) ) $form_values['campaign_id'] = $config['campaign_id'];
 
 			if ( ! empty( $config['registered_by_id'] ) ) {
-				$form_values['registered_by_id'] = flase !== strpos( $config['registered_by_id'], 'contact_' )
+				$form_values['registered_by_id'] = false !== strpos( $config['registered_by_id'], 'contact_' )
 					? $transient->contacts->{'cid_' . str_replace( 'contact_', '', $config['creator_id'] )}
 					: $config['registered_by_id'];
 			}


### PR DESCRIPTION
# Please make all Pull Requests against the dev branch 

Overview
----------------------------------------
There was a misspelling in the word "false" 

Before
----------------------------------------
It would always assume that the string matched the contact.

After
----------------------------------------
It can get to the second part of the ternary operator.
